### PR TITLE
Fix bug on fetch call error handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,12 +9,13 @@ const App = () => {
   const [selectedImage, setSelectedImage] = useState<{}>({})
   const [calendarImages, setCalendarImages] = useState<object[]>([])
   const [finalCalendar, setFinalCalendar] = useState<object[]>([])
+  const [error, setError] = useState<boolean>(false)
 
   return (
     <main>
       <Routes>
         <Route path='/' element={<Home/>}/>
-        <Route path="/Images" element={<Images selectedImage={selectedImage} setSelectedImage={setSelectedImage} setCalendarImages={setCalendarImages} calendarImages={calendarImages} setFinalCalendar={setFinalCalendar}/>}/>
+        <Route path="/Images" element={<Images selectedImage={selectedImage} setSelectedImage={setSelectedImage} setCalendarImages={setCalendarImages} calendarImages={calendarImages} setFinalCalendar={setFinalCalendar} error={error} setError={setError}/>}/>
         <Route path="/Calendar" element={<Calendar calendarImages={calendarImages} setCalendarImages={setCalendarImages} finalCalendar={finalCalendar} setFinalCalendar={setFinalCalendar}/>}/>
       </Routes>
     </main>

--- a/src/Components/DatePicker.tsx
+++ b/src/Components/DatePicker.tsx
@@ -4,12 +4,21 @@ import { getImageByDate } from '../apiCalls';
 
 type DatePicker = {
   setSelectedImage: React.Dispatch<React.SetStateAction<any>>
+  setError: React.Dispatch<React.SetStateAction<boolean>>
 }
-const DatePicker: React.FC<DatePicker> = ({setSelectedImage}) => {
+const DatePicker: React.FC<DatePicker> = ({setSelectedImage, setError}) => {
   const [value, setValue] = useState<string>('');
 
   const handleClick = (event: React.MouseEvent<HTMLElement>, text: string) => {
     getImageByDate(value)
+    .then(response => {
+        if (response.ok) {
+          setError(false)
+          return response.json();
+        } else {
+          setError(true)
+        }
+    })
     .then(data => setSelectedImage(data))
   };
 

--- a/src/Screens/Images.tsx
+++ b/src/Screens/Images.tsx
@@ -61,6 +61,8 @@ type Images = {
   calendarImages: Image[];
   setCalendarImages: React.Dispatch<React.SetStateAction<object[]>>
   setFinalCalendar: React.Dispatch<React.SetStateAction<object[]>>
+  error: boolean;
+  setError: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 type Image= {
@@ -75,14 +77,23 @@ type Image= {
 
 theme = responsiveFontSizes(theme)
 
-const Images: React.FC<Images> = ({selectedImage, setSelectedImage, setCalendarImages, calendarImages, setFinalCalendar}) => {
+const Images: React.FC<Images> = ({selectedImage, setSelectedImage, setCalendarImages, calendarImages, setFinalCalendar, error, setError}) => {
   const monthNames: string[] = ['JANUARY', 'FEBRUARY', 'MARCH', 'APRIL', 'MAY', 'JUNE', 'JULY', 'AUGUST', 'SEPTEMBER', 'OCTOBER', 'NOVEMBER', 'DECEMBER']
 
   const todaysDate = new Date().toISOString().slice(0, 10)
 
   useEffect(() => {
     getImageByDate('2022-01-13')
+    .then(response => {
+      if (response.ok) {
+        setError(false)
+        return response.json();
+      } else {
+        setError(true)
+      }
+    })
     .then(data => setSelectedImage(data))
+    // .catch(() => setError(true))
   }, [])
 
   const handleClick = (event: React.MouseEvent<HTMLElement>, text: string) => {
@@ -149,7 +160,7 @@ const Images: React.FC<Images> = ({selectedImage, setSelectedImage, setCalendarI
           </Grid>
         </Grid>
       <Grid container spacing={2} justifyContent='center'>
-        <DatePicker setSelectedImage={setSelectedImage}/>
+        <DatePicker setSelectedImage={setSelectedImage} setError={setError}/>
       </Grid>
       <Grid container spacing={2} justifyContent='center' mt='20px'>
         {calendarImages.length > 0?
@@ -178,6 +189,7 @@ const Images: React.FC<Images> = ({selectedImage, setSelectedImage, setCalendarI
           </>
         }
       </Grid>
+      {!error && selectedImage.media_type === 'image' ?
       <Grid container sx={{justifyContent:'center'}}>
         <Grid item xs={12} sm={8} md={8} >
           <Card sx={{mt: '30px', justifyContent:'center'}}>
@@ -208,6 +220,15 @@ const Images: React.FC<Images> = ({selectedImage, setSelectedImage, setCalendarI
           </Card>
         </Grid>
       </Grid>
+        :
+        <Grid container sx={{justifyContent:'center'}}>
+            <Grid item>
+              <Typography variant='h4' component='h4' sx={{mr:'25px', ml: '25px', mt: '25px'}}>
+                Image unavailable please try another date. 
+              </Typography>
+            </Grid>
+          </Grid>
+       }
     </ThemeProvider>  
     <Toolbar></Toolbar>
     </Container>

--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -1,13 +1,7 @@
 const getImageByDate = (date:string) => {
   return (
     fetch(`https://api.nasa.gov/planetary/apod?api_key=m5I8olTgrZThXai6adDlgLeX8cUOlJ69IzMVpT7w&date=${date}`)
-    .then(response => {
-      if (response.ok) {
-        return response.json();
-      } else {
-        throw new Error();
-      }
-    })
+    
   )
 }
 


### PR DESCRIPTION
# Description <img src="https://www.freepnglogos.com/uploads/mars-png/mars-transparent-png-stickpng-0.png" alt="drawing" width="50"/>

Fix fetch call to throw an error with bad api call. User should see error message to chose another date if selected date does not have an image or if the api call comes back with a 400 error. 

## Issues

Closes # 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor feature (non-breaking change that modifies existing work)
- [ ] Cosmetic changes (changes to layout or visuals in CSS file)


# How Has This Been Tested?

- [x] console.log()
- [x] dev tools
- [x] functionality check through web browser



# Checklist:

- [x] My code follows the style guidelines of this project (semicolons, indentation, naming conventions, etc..)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have deleted all comments/console.log() after functionality and understanding is final
- [x] I have added any issues closed by this PR in the Issues section.
- [x] I have added others as reviewers
